### PR TITLE
Datetime64 field type support

### DIFF
--- a/lib/click_house.rb
+++ b/lib/click_house.rb
@@ -41,6 +41,11 @@ module ClickHouse
     add_type "Nullable(#{column})", Type::NullableType.new(Type::DateTimeType.new)
   end
 
+  ['DateTime64(%d, %s)'].each do |column|
+    add_type column, Type::DateTime64Type.new
+    add_type "Nullable(#{column})", Type::NullableType.new(Type::DateTime64Type.new)
+  end
+
   ['Decimal(%s, %s)', 'Decimal32(%s)', 'Decimal64(%s)', 'Decimal128(%s)'].each do |column|
     add_type column, Type::DecimalType.new
     add_type "Nullable(#{column})", Type::NullableType.new(Type::DecimalType.new)

--- a/lib/click_house/definition/column_set.rb
+++ b/lib/click_house/definition/column_set.rb
@@ -11,7 +11,7 @@ module ClickHouse
         'FixedString(%d)',
         'UUID',
         'Date',
-        "DateTime('%s')"
+        "DateTime('%s')", "DateTime64(%d, '%s')"
       ].freeze
 
       class << self

--- a/lib/click_house/type.rb
+++ b/lib/click_house/type.rb
@@ -7,6 +7,7 @@ module ClickHouse
     autoload :UndefinedType, 'click_house/type/undefined_type'
     autoload :DateType, 'click_house/type/date_type'
     autoload :DateTimeType, 'click_house/type/date_time_type'
+    autoload :DateTime64Type, 'click_house/type/date_time64_type'
     autoload :IntegerType, 'click_house/type/integer_type'
     autoload :FloatType, 'click_house/type/float_type'
     autoload :BooleanType, 'click_house/type/boolean_type'

--- a/lib/click_house/type/date_time64_type.rb
+++ b/lib/click_house/type/date_time64_type.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ClickHouse
+  module Type
+    class DateTime64Type < BaseType
+      def cast(value, _precision = nil, tz = nil)
+        DateTime.parse("#{value} #{tz}")
+      end
+
+      def serialize(value, precision = 3)
+        value.strftime("%Y-%m-%d %H:%M:%S.%#{precision}N")
+      end
+    end
+  end
+end

--- a/spec/click_house/definition/column_set_spec.rb
+++ b/spec/click_house/definition/column_set_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe ClickHouse::Definition::ColumnSet do
           n.UInt8 :cid, nullable: true
           n.Date  :created_at, default: 'NOW()'
           n.DateTime :updated_at, 'UTC'
+          n.DateTime64 :deleted_at, 6, 'UTC'
         end
         t << "words Enum('hello' = 1, 'world' = 2)"
         t << "tags Array(String)"
@@ -26,7 +27,8 @@ RSpec.describe ClickHouse::Definition::ColumnSet do
           json Nested ( 
                         cid Nullable(UInt8) , 
                         created_at Date DEFAULT NOW(), 
-                        updated_at DateTime('UTC')  
+                        updated_at DateTime('UTC'),
+                        deleted_at DateTime64(6, 'UTC')  
                       ), 
           words Enum('hello' = 1, 'world' = 2), 
           tags Array(String) 

--- a/spec/click_house/extend/connection_altering_spec.rb
+++ b/spec/click_house/extend/connection_altering_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ClickHouse::Extend::ConnectionAltering do
       it 'works' do
         expect(subject.describe_table('rspec').map { |r| r['name'] }).to eq(%w[date account_id id user_id])
         expect(column).to include('type' => 'UInt64')
-        expect(column).to include('default_expression' => "CAST(0, 'UInt64')")
+        expect(column).to include('default_expression' => '0')
       end
     end
 
@@ -102,7 +102,7 @@ RSpec.describe ClickHouse::Extend::ConnectionAltering do
       end
 
       it 'works' do
-        expect { function }.to change { column.call.values_at('type', 'default_expression') }.to(['UInt64', "CAST(0, 'UInt64')"])
+        expect { function }.to change { column.call.values_at('type', 'default_expression') }.to(['UInt64', '0'])
       end
     end
 

--- a/spec/click_house/extend/connection_table_spec.rb
+++ b/spec/click_house/extend/connection_table_spec.rb
@@ -190,6 +190,7 @@ RSpec.describe ClickHouse::Extend::ConnectionTable do
           t.UInt16      :year
           t.Date        :date
           t.DateTime    :time, 'UTC'
+          t.DateTime64  :time_with_usec, 4, 'UTC'
           t.Decimal     :money, 5, 4
           t.String      :event, nullable: true
           t.Nested      :json do |n|
@@ -211,6 +212,7 @@ RSpec.describe ClickHouse::Extend::ConnectionTable do
         expect(columns.fetch('year')).to include('type' => 'UInt16', 'default_expression' => '', 'ttl_expression' => '')
         expect(columns.fetch('date')).to include('type' => 'Date', 'default_expression' => '', 'ttl_expression' => '')
         expect(columns.fetch('time')).to include('type' => "DateTime('UTC')", 'default_expression' => '', 'ttl_expression' => '')
+        expect(columns.fetch('time_with_usec')).to include('type' => "DateTime64(4, 'UTC')", 'default_expression' => '', 'ttl_expression' => '')
         expect(columns.fetch('money')).to include('type' => 'Decimal(5, 4)', 'default_expression' => '', 'ttl_expression' => '')
         expect(columns.fetch('event')).to include('type' => 'Nullable(String)', 'default_expression' => '', 'ttl_expression' => '')
         expect(columns.fetch('json.cid')).to include('type' => 'Array(UInt8)', 'default_expression' => '', 'ttl_expression' => '')


### PR DESCRIPTION
According to https://clickhouse.tech/docs/en/data_types/datetime64/

PS: also fix failing specs for current clickhouse.