### PR TITLE
Customize headers in HTTP requests to Clickhouse server

### DIFF
--- a/lib/click_house/config.rb
+++ b/lib/click_house/config.rb
@@ -18,7 +18,8 @@ module ClickHouse
       password: nil,
       timeout: nil,
       open_timeout: nil,
-      ssl_verify: false
+      ssl_verify: false,
+      headers: {}
     }.freeze
 
     attr_accessor :adapter
@@ -33,6 +34,7 @@ module ClickHouse
     attr_accessor :timeout
     attr_accessor :open_timeout
     attr_accessor :ssl_verify
+    attr_accessor :headers
 
     def initialize(params = {})
       assign(DEFAULTS.merge(params))

--- a/lib/click_house/connection.rb
+++ b/lib/click_house/connection.rb
@@ -20,11 +20,11 @@ module ClickHouse
     end
 
     def get(path = '/', query: {}, database: config.database)
-      transport.get(compose(path, query.merge(database: database)))
+      transport.get(compose(path, query.merge(database: database)), config.headers)
     end
 
     def post(body = nil, query: {}, database: config.database)
-      transport.post(compose('/', query.merge(database: database)), body)
+      transport.post(compose('/', query.merge(database: database)), body, config.headers)
     end
 
     def transport


### PR DESCRIPTION
Some SaaS providers use authentication on Clickhouse servers and sometimes it goes beyond basic authorization.

Yandex Cloud for example uses header authorization, requiring you to provide credentials in specific headers. With that MR you can.