### PR TITLE
Send query in GET body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.bundle/
 /.yardoc
+/.idea/
 /_yardoc/
 /coverage/
 /pkg/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+# 1.5.0
+* add support for 'WITH TOTALS' modifier in response
+
 # 1.4.0
-* fizx decimal type casting [#11](https://github.com/shlima/click_house/issues/11)
+* fix decimal type casting [#11](https://github.com/shlima/click_house/issues/11)
 
 # 1.3.9
 * add `ClickHouse.connection.add_index`, `ClickHouse.connection.drop_index`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    click_house (1.4.0)
+    click_house (1.5.0)
       faraday
       faraday_middleware
 
@@ -11,11 +11,15 @@ GEM
     ast (2.4.2)
     coderay (1.1.3)
     diff-lcs (1.4.4)
-    faraday (1.3.0)
+    faraday (1.4.1)
+      faraday-excon (~> 1.1)
       faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
       multipart-post (>= 1.2, < 3)
-      ruby2_keywords
+      ruby2_keywords (>= 0.0.4)
+    faraday-excon (1.1.0)
     faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.1.0)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     method_source (1.0.0)

--- a/lib/click_house/extend/connection_healthy.rb
+++ b/lib/click_house/extend/connection_healthy.rb
@@ -4,8 +4,7 @@ module ClickHouse
   module Extend
     module ConnectionHealthy
       def ping
-        # without +send_progress_in_http_headers: nil+ DB::Exception: Empty query returns
-        get(database: nil, query: { send_progress_in_http_headers: nil }).success?
+        get('/ping', database: nil).success?
       end
 
       def replicas_status

--- a/lib/click_house/extend/connection_selective.rb
+++ b/lib/click_house/extend/connection_selective.rb
@@ -5,17 +5,17 @@ module ClickHouse
     module ConnectionSelective
       # @return [ResultSet]
       def select_all(sql)
-        response = execute(Util::Statement.format(sql, 'JSON'))
+        response = get(query: Util::Statement.format(sql, 'JSON'))
         Response::Factory[response]
       end
 
       def select_value(sql)
-        response = execute(Util::Statement.format(sql, 'JSON'))
+        response = get(query: Util::Statement.format(sql, 'JSON'))
         Array(Response::Factory[response].first).dig(0, -1)
       end
 
       def select_one(sql)
-        response = execute(Util::Statement.format(sql, 'JSON'))
+        response = get(query: Util::Statement.format(sql, 'JSON'))
         Response::Factory[response].first
       end
     end

--- a/lib/click_house/response/factory.rb
+++ b/lib/click_house/response/factory.rb
@@ -10,7 +10,9 @@ module ClickHouse
 
         return body if !body.is_a?(Hash) || !(body.key?('meta') && body.key?('data'))
 
-        ResultSet.new(meta: body.fetch('meta'), data: body.fetch('data'), statistics: body['statistics'])
+        ResultSet.new(
+          meta: body.fetch('meta'), data: body.fetch('data'), totals: body['totals'], statistics: body['statistics']
+        )
       end
     end
   end

--- a/lib/click_house/response/result_set.rb
+++ b/lib/click_house/response/result_set.rb
@@ -14,7 +14,7 @@ module ClickHouse
                      :inspect, :each, :fetch, :length, :count, :size,
                      :first, :last, :[], :to_h
 
-      attr_reader :meta, :data, :statistics
+      attr_reader :meta, :data, :totals, :statistics
 
       class << self
         # @return [Array<String, Array>]
@@ -48,9 +48,13 @@ module ClickHouse
 
       # @param meta [Array]
       # @param data [Array]
-      def initialize(meta:, data:, statistics: nil)
+      # @param totals [Array|Hash|NilClass] Support for 'GROUP BY WITH TOTALS' modifier
+      #   https://clickhouse.tech/docs/en/sql-reference/statements/select/group-by/#with-totals-modifier
+      #   Hash in JSON format and Array in JSONCompact
+      def initialize(meta:, data:, totals: nil, statistics: nil)
         @meta = meta
         @data = data
+        @totals = totals
         @statistics = Hash(statistics)
       end
 

--- a/lib/click_house/version.rb
+++ b/lib/click_house/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ClickHouse
-  VERSION = '1.4.0'
+  VERSION = '1.5.0'
 end


### PR DESCRIPTION
Hi @shlima, I would like to propose some changes:
- Send all `select_*` requests through GET, Clickhouse marks all GET requests as readonly, so this change increases security, and it also more idiomatic to fetch data through GET
- Send SQL query in GET request in body, so there is no limit for query length
- Log duration of query spent in CH server, this is useful to compare with time spent to download and parse response. Supported by JSON* formats. Example message `SQL (Total: 135MS, CH: 1MS) select number from system.numbers limit 10 format JSON`
- Fix log of duration, it expects time in milliseconds but receives it in seconds
- Add support for 'WITH TOTALS' modifier in response

PS. I can split pull request in several if it it easier for you