### PR TITLE
Fix Faraday deprecation

### DIFF
--- a/lib/click_house/connection.rb
+++ b/lib/click_house/connection.rb
@@ -52,7 +52,7 @@ module ClickHouse
         conn.options.open_timeout = config.open_timeout
         conn.headers = config.headers
         conn.ssl.verify = config.ssl_verify
-        conn.basic_auth(config.username, config.password) if config.auth?
+        conn.request(:basic_auth, config.username, config.password) if config.auth?
         conn.response Middleware::Logging, logger: config.logger!
         conn.response Middleware::RaiseError
         conn.response :json, content_type: %r{application/json}

--- a/spec/click_house/config_spec.rb
+++ b/spec/click_house/config_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe ClickHouse::Config do
 
       it 'is true' do
         expect(subject.auth?).to eq(true)
-        expect(ClickHouse.connection.select_one('SELECT * FROM rspec')).to eq('tags' => ['Be1rger King', "McDonald’s"])
       end
     end
   end

--- a/spec/click_house/config_spec.rb
+++ b/spec/click_house/config_spec.rb
@@ -41,8 +41,9 @@ RSpec.describe ClickHouse::Config do
         subject.password = 'bar'
       end
 
-      it 'is false' do
+      it 'is true' do
         expect(subject.auth?).to eq(true)
+        expect(ClickHouse.connection.select_one('SELECT * FROM rspec')).to eq('tags' => ['Be1rger King', "McDonald’s"])
       end
     end
   end


### PR DESCRIPTION
When using click_house gem with faraday@1.7:

```
WARNING: `Faraday::Connection#basic_auth` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:basic_auth, ...)` instead.
```

https://github.com/lostisland/faraday/pull/1306