### PR TITLE
handle value returned as nil in float and integer types (case of Aggregate Function Combinators)

### DIFF
--- a/lib/click_house/type/float_type.rb
+++ b/lib/click_house/type/float_type.rb
@@ -4,7 +4,7 @@ module ClickHouse
   module Type
     class FloatType < BaseType
       def cast(value)
-        Float(value)
+        Float(value) unless value.nil?
       end
 
       def serialize(value)

--- a/lib/click_house/type/integer_type.rb
+++ b/lib/click_house/type/integer_type.rb
@@ -4,7 +4,7 @@ module ClickHouse
   module Type
     class IntegerType < BaseType
       def cast(value)
-        Integer(value)
+        Integer(value) unless value.nil?
       end
 
       def serialize(value)

--- a/spec/click_house/type/float_type_spec.rb
+++ b/spec/click_house/type/float_type_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe ClickHouse::Type::FloatType do
+  describe '#serialize' do
+    it 'works' do
+      expect(subject.serialize(5)).to be_a(Float)
+      expect(subject.serialize(5)).to eq(5.0)
+      expect(subject.serialize(5.0)).to eq(5.0)
+      expect(subject.serialize(nil)).to eq(nil)
+    end
+  end
+
+  describe '#cast' do
+    it 'works' do
+      expect(subject.cast(5)).to be_a(Float)
+      expect(subject.cast(5)).to eq(5.0)
+      expect(subject.cast(5.0)).to eq(5.0)
+      expect(subject.cast(nil)).to eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
when we use [Aggregate Function Combinators](https://clickhouse.com/docs/en/sql-reference/aggregate-functions/combinators/#agg-functions-combinator-if) it result in some fields have value = `nil` which results in:
```
     TypeError:
       can't convert nil into Float

     # /bundle/ruby/2.6.0/gems/click_house-1.5.0/lib/click_house/type/float_type.rb:7:in `Float'
     # /bundle/ruby/2.6.0/gems/click_house-1.5.0/lib/click_house/type/float_type.rb:7:in `cast'
     # /bundle/ruby/2.6.0/gems/click_house-1.5.0/lib/click_house/response/result_set.rb:65:in `block (2 levels) in to_a'
     # /bundle/ruby/2.6.0/gems/click_house-1.5.0/lib/click_house/response/result_set.rb:63:in `each'
``` 

example query:
```
SELECT key, quantileTDigestIf(0.50)(count, count > 10)
FROM 
(
    SELECT
        1000 AS key,
        10 AS count
    UNION ALL
    SELECT
        3000,
        500
)
GROUP BY key
```
results:
```
┌──key─┬─quantileTDigestIf(0.5)(count, greater(count, 10))─┐
│ 1000 │                                               nan │
│ 3000 │                                               500 │
└──────┴───────────────────────────────────────────────────┘
```