### PR TITLE
CI: Use bundler-cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [3.1, 3.0, 2.7, 2.6]
+        ruby-version: [3.1, '3.0', 2.7, 2.6]
 
     steps:
       - uses: actions/checkout@v2
@@ -23,19 +23,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-
-      - name: Cache gems
-        uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-${{ matrix.ruby-version }}-bundler-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.ruby-version }}-bundler-
-
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true # 'bundle install' and cache
 
       - name: Run tests
         run: bundle exec rspec
@@ -50,19 +38,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-
-      - name: Cache gems
-        uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-bundler-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bundler-
-
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true # 'bundle install' and cache
 
       - name: Run Rubocop
         run: bundle exec rubocop


### PR DESCRIPTION

This PR uses the `bundler-cache` feature of the Ruby-maintained Action `ruby/setup-ruby`.

[See `ruby/setup-ruby` parameters declaration](https://github.com/ruby/setup-ruby/blob/master/action.yml) for more information.


---

This also avoid a Float-to-String data loss 3.0 -> "3".

This is a very small change, but which avoids a Float-to-String loss of characters.

An example (not from this project) of what it can look like before this change, in this picture:

<img width="376" alt="bild" src="https://user-images.githubusercontent.com/211/119782378-6ad6cd00-becc-11eb-9e13-9a425adaa054.png">

Read more details, if you like: https://github.com/actions/runner/issues/849