### PR TITLE
Drop unused directives from gemspec

### DIFF
--- a/click_house.gemspec
+++ b/click_house.gemspec
@@ -17,8 +17,6 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
   spec.add_dependency 'faraday', '>= 1.7'


### PR DESCRIPTION
This gem exposes no executables.