### PR TITLE
Return empty list rather than nil for empty CSV

### DIFF
--- a/lib/click_house/middleware/parse_csv.rb
+++ b/lib/click_house/middleware/parse_csv.rb
@@ -10,7 +10,7 @@ module ClickHouse
       end
 
       define_parser do |body, parser_options|
-        CSV.parse(body, **Hash.new(parser_options)) unless body.strip.empty?
+        CSV.parse(body, **Hash.new(parser_options))
       end
     end
   end


### PR DESCRIPTION
The current behaviour returns `nil` if a query with `FORMAT CSV` returns no data. This can be cumbersome for callers, since if you wish to iterate through the results, something like this will crash when the query returns no data:
``` ruby
query = "SELECT id, name, email FROM users WHERE [condition_satisfied_by_no_users] FORMAT CSV"
result = ClickHouse.connection.execute(query).body

result.each do |row|       # <-- this crashes because result is nil
   # process row
end
```

We're working around this everywhere we use CSV queries by catching `nil` and replacing it with `[]`:
``` ruby
result = ClickHouse.connection.execute(query).body || []
```

This pull request changes the CSV parser middleware to return an empty array instead. I realise this is technically backwards-incompatible: Existing users that rely on empty results being falsey will need to update their code to check `result.empty?` instead. But it seems counterintuitive to me that it returns `nil` rather than an empty array, and I respectfully suggest that this proposal would be the more consistent behaviour.

-----------------

**Note on `body.strip.empty?` check:** When I try this, it gives me an empty body (as opposed to an all-whitespace body) when there's no data to return, so I haven't seen the `body.strip.empty?` check come into play. But if there are cases where an all-whitespace response needs to be interpreted as empty rather than `"   "`, this would work:
``` ruby
        if body.strip.empty?
          []
        else
          CSV.parse(body, **Hash.new(parser_options))
        end
```