### PR TITLE
Force JSON format by using "default_format" instead of modifying the query

### DIFF
--- a/lib/click_house/extend/connection_selective.rb
+++ b/lib/click_house/extend/connection_selective.rb
@@ -5,17 +5,17 @@ module ClickHouse
     module ConnectionSelective
       # @return [ResultSet]
       def select_all(sql)
-        response = get(body: Util::Statement.format(sql, 'JSON'))
+        response = get(body: sql, query: { default_format: 'JSON' })
         Response::Factory[response]
       end
 
       def select_value(sql)
-        response = get(body: Util::Statement.format(sql, 'JSON'))
+        response = get(body: sql, query: { default_format: 'JSON' })
         Array(Response::Factory[response].first).dig(0, -1)
       end
 
       def select_one(sql)
-        response = get(body: Util::Statement.format(sql, 'JSON'))
+        response = get(body: sql, query: { default_format: 'JSON' })
         Response::Factory[response].first
       end
     end

--- a/lib/click_house/util/statement.rb
+++ b/lib/click_house/util/statement.rb
@@ -3,19 +3,10 @@
 module ClickHouse
   module Util
     module Statement
-      END_OF_STATEMENT = ';'
-      END_OF_STATEMENT_RE = /#{END_OF_STATEMENT}(\s+|\Z)/.freeze
-
       module_function
 
       def ensure(truthful, value, fallback = nil)
         truthful ? value : fallback
-      end
-
-      def format(sql, format)
-        return sql if sql.match?(/FORMAT/i)
-
-        "#{sql.sub(END_OF_STATEMENT_RE, '')} FORMAT #{format};"
       end
     end
   end


### PR DESCRIPTION
This should be a more robust way of asking for the JSON format. 

Matching the SQL query for the FORMAT clause with regex had the following issue. If you run this query through the ClickHouse gem:

```sql
SELECT text FROM my_table WHERE text LIKE 'informatica'
```

it won't append the `FORMAT JSON` clause and it will raise an error when attempting to parse the resulting CSV as JSON.

https://clickhouse.com/docs/en/interfaces/http

<img width="1135" alt="Screenshot 2022-05-17 at 12 33 43" src="https://user-images.githubusercontent.com/2053337/168792064-8f94891b-9000-44bb-a591-43c19b590953.png">

