### PR TITLE
Add rows_before_limit_at_least to ResultSet 

### DIFF
--- a/lib/click_house/connection.rb
+++ b/lib/click_house/connection.rb
@@ -55,7 +55,7 @@ module ClickHouse
         conn.request(:basic_auth, config.username, config.password) if config.auth?
         conn.response Middleware::RaiseError
         conn.response Middleware::Logging, logger: config.logger!
-        conn.response :json, content_type: %r{application/json}
+        conn.response :json
         conn.response Middleware::ParseCsv, content_type: %r{text/csv}
         conn.adapter config.adapter
       end

--- a/lib/click_house/response/factory.rb
+++ b/lib/click_house/response/factory.rb
@@ -14,7 +14,8 @@ module ClickHouse
           meta: body.fetch('meta'),
           data: body.fetch('data'),
           totals: body['totals'],
-          statistics: body['statistics']
+          statistics: body['statistics'],
+          rows_before_limit_at_least: body['rows_before_limit_at_least']
         )
       end
     end

--- a/lib/click_house/response/result_set.rb
+++ b/lib/click_house/response/result_set.rb
@@ -14,7 +14,7 @@ module ClickHouse
                      :inspect, :each, :fetch, :length, :count, :size,
                      :first, :last, :[], :to_h
 
-      attr_reader :meta, :data, :totals, :statistics
+      attr_reader :meta, :data, :totals, :statistics, :rows_before_limit_at_least
 
       class << self
         # @return [Array<String, Array>]
@@ -51,10 +51,11 @@ module ClickHouse
       # @param totals [Array|Hash|NilClass] Support for 'GROUP BY WITH TOTALS' modifier
       #   https://clickhouse.tech/docs/en/sql-reference/statements/select/group-by/#with-totals-modifier
       #   Hash in JSON format and Array in JSONCompact
-      def initialize(meta:, data:, totals: nil, statistics: nil)
+      def initialize(meta:, data:, totals: nil, statistics: nil, rows_before_limit_at_least: nil)
         @meta = meta
         @data = data
         @totals = totals
+        @rows_before_limit_at_least = rows_before_limit_at_least
         @statistics = Hash(statistics)
       end
 

--- a/lib/click_house/response/result_set.rb
+++ b/lib/click_house/response/result_set.rb
@@ -54,7 +54,7 @@ module ClickHouse
       def initialize(meta:, data:, totals: nil, statistics: nil, rows_before_limit_at_least: nil)
         @meta = meta
         @data = data
-        @totals = totals
+        @totals = totals || rows_before_limit_at_least
         @rows_before_limit_at_least = rows_before_limit_at_least
         @statistics = Hash(statistics)
       end


### PR DESCRIPTION
```json
{
        "meta":
        [
                {
                        "name": "num",
                        "type": "Int32"
                },
                {
                        "name": "str",
                        "type": "String"
                },
                {
                        "name": "arr",
                        "type": "Array(UInt8)"
                }
        ],

        "data":
        [
                {
                        "num": 42,
                        "str": "hello",
                        "arr": [0,1]
                },
                {
                        "num": 43,
                        "str": "hello",
                        "arr": [0,1,2]
                },
                {
                        "num": 44,
                        "str": "hello",
                        "arr": [0,1,2,3]
                }
        ],

        "rows": 3,

        "rows_before_limit_at_least": 3,

        "statistics":
        {
                "elapsed": 0.001137687,
                "rows_read": 3,
                "bytes_read": 24
        }
}
```
https://clickhouse.com/docs/en/interfaces/formats/#json

ClickHouse server version 22.5.1 **totals** not working 