### PR TITLE
Support X-ClickHouse-Exception-Code header

### DIFF
--- a/lib/click_house/connection.rb
+++ b/lib/click_house/connection.rb
@@ -53,9 +53,9 @@ module ClickHouse
         conn.headers = config.headers
         conn.ssl.verify = config.ssl_verify
         conn.request(:basic_auth, config.username, config.password) if config.auth?
+        conn.response :json, content_type: %r{application/json}
         conn.response Middleware::RaiseError
         conn.response Middleware::Logging, logger: config.logger!
-        conn.response :json, content_type: %r{application/json}
         conn.response Middleware::ParseCsv, content_type: %r{text/csv}
         conn.adapter config.adapter
       end

--- a/lib/click_house/middleware/raise_error.rb
+++ b/lib/click_house/middleware/raise_error.rb
@@ -16,6 +16,11 @@ module ClickHouse
       private
 
       def on_complete(env)
+        # Valid since Clickhouse 22.6
+        if env.response_headers.key?('X-ClickHouse-Exception-Code')
+          raise DbException, env.body
+        end
+
         return if SUCCEED_STATUSES.include?(env.status)
 
         raise DbException, "[#{env.status}] #{env.body}"


### PR DESCRIPTION
Clickhouse 22.6 introduced `X-ClickHouse-Exception-Code` which you can check for any errors. This is especially useful when we use the `send_progress_in_http_headers` parameter, as in this case, the ClickHouse server doesn't really respond with proper HTTP codes.

Without this change, the library raises a `Faraday::ParsingError`, because:
1. The parsing middleware is invoked first
2. The RaiseError middleware ignores the error because the response code is 200


Before:

```
irb(main):001:0> ClickHouse.connection.get(body: 'select sleep(3)', query: { default_format: 'JSON', max_execution_time: 1 })
/Users/kacper/.rbenv/versions/3.1.0/lib/ruby/3.1.0/json/common.rb:216:in `parse': 859: unexpected token at 'Code: 159. DB::Exception: Timeout exceeded: elapsed 3.000871126 seconds, maximum: 1. (TIMEOUT_EXCEEDED) (version 22.4.4.7 (official build)) (Faraday::ParsingError)
'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/3.1.0/json/common.rb:216:in `parse'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response/parse_json.rb:13:in `block in <class:ParseJson>'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:54:in `parse'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:43:in `process_response'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:37:in `block in call'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/faraday-1.10.0/lib/faraday/response.rb:61:in `on_complete'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:36:in `call'
	from /Users/kacper/Development/docker-development/repos/click_house/lib/click_house/middleware/logging.rb:20:in `call'
	from /Users/kacper/Development/docker-development/repos/click_house/lib/click_house/middleware/raise_error.rb:11:in `call'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/faraday-1.10.0/lib/faraday/rack_builder.rb:154:in `build_response'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/faraday-1.10.0/lib/faraday/connection.rb:516:in `run_request'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/faraday-1.10.0/lib/faraday/connection.rb:200:in `get'
	from /Users/kacper/Development/docker-development/repos/click_house/lib/click_house/connection.rb:38:in `get'
	from (irb):1:in `<main>'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/3.1.0/bundler/cli/console.rb:19:in `run'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/3.1.0/bundler/cli.rb:514:in `console'
	... 11 levels...
```

After:

```
irb(main):001:0> ClickHouse.connection.get(body: 'select sleep(3)', query: { default_format: 'JSON', max_execution_time: 1 })
/Users/kacper/Development/docker-development/repos/click_house/lib/click_house/middleware/raise_error.rb:21:in `on_complete': Code: 159. DB::Exception: Timeout exceeded: elapsed 3.00171971 seconds, maximum: 1. (TIMEOUT_EXCEEDED) (version 22.4.4.7 (official build)) (ClickHouse::DbException)
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/faraday-1.10.0/lib/faraday/response.rb:61:in `on_complete'
	from /Users/kacper/Development/docker-development/repos/click_house/lib/click_house/middleware/raise_error.rb:11:in `call'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:36:in `call'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/faraday-1.10.0/lib/faraday/rack_builder.rb:154:in `build_response'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/faraday-1.10.0/lib/faraday/connection.rb:516:in `run_request'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/faraday-1.10.0/lib/faraday/connection.rb:200:in `get'
	from /Users/kacper/Development/docker-development/repos/click_house/lib/click_house/connection.rb:38:in `get'
	from (irb):1:in `<main>'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/3.1.0/bundler/cli/console.rb:19:in `run'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/3.1.0/bundler/cli.rb:514:in `console'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from /Users/kacper/.rbenv/versions/3.1.0/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'
	... 5 levels...
```

Example `env.body`:

```
"Code: 159. DB::Exception: Timeout exceeded: elapsed 1.013306895 seconds, maximum: 1. (TIMEOUT_EXCEEDED) (version 22.6.2.12 (official build))\n"
```
