### PR TITLE
Add option format for insert

### DIFF
--- a/lib/click_house/extend/connection_inserting.rb
+++ b/lib/click_house/extend/connection_inserting.rb
@@ -14,8 +14,8 @@ module ClickHouse
       # end
       #
       # == Example with a param
-      # subject.insert('rspec', values: [{ name: 'Sun', id: 1 }, { name: 'Moon', id: 2 }])
-      def insert(table, columns: [], values: [])
+      # subject.insert('rspec', values: [{ name: 'Sun', id: 1 }, { name: 'Moon', id: 2 }], format: 'JSONStringsEachRow')
+      def insert(table, columns: [], values: [], format: 'JSONEachRow')
         yield(values) if block_given?
 
         body = if columns.empty?
@@ -26,7 +26,7 @@ module ClickHouse
 
         return EMPTY_INSERT if values.empty?
 
-        execute("INSERT INTO #{table} FORMAT JSONEachRow", body.join("\n")).success?
+        execute("INSERT INTO #{table} FORMAT #{format}", body.join("\n")).success?
       end
     end
   end

--- a/spec/click_house/extend/connection_inserting_spec.rb
+++ b/spec/click_house/extend/connection_inserting_spec.rb
@@ -20,6 +20,17 @@ RSpec.describe ClickHouse::Extend::ConnectionInserting do
       expect(insert).to eq(true)
       expect(subject.select_value('SELECT COUNT(*) FROM rspec')).to eq(2)
     end
+
+    context 'when string format' do
+      let(:insert) do
+        subject.insert('rspec', columns: %i[name id], values: [%w[Sun 1], %w[Moon 2]], format: 'JSONStringsEachRow')
+      end
+
+      it 'works' do
+        expect(insert).to eq(true)
+        expect(subject.select_value('SELECT COUNT(*) FROM rspec')).to eq(2)
+      end
+    end
   end
 
   context 'when argument with columns' do


### PR DESCRIPTION
Sometimes it's needed to use other format than JSONEachRow 
For example if you want to send BigDecimal's you could use JSONStringsEachRow format so string representation of BigDecimal will be parsed
This PR adds option to specify format like this
`insert('rspec', values: [{ name: 'Sun', id: 1 }, { name: 'Moon', id: 2 }], format: 'JSONStringsEachRow')`