### PR TITLE
Put RaiseError middleware at the end of the middleware chain

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,14 +13,19 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    addressable (2.8.5)
+      public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
+    crack (0.4.5)
+      rexml
     diff-lcs (1.5.0)
     faraday (2.7.1)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
+    hashdiff (1.0.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.2)
@@ -33,6 +38,7 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    public_suffix (5.0.3)
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.6.1)
@@ -70,6 +76,10 @@ GEM
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.3.0)
+    webmock (3.19.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   ruby
@@ -83,6 +93,7 @@ DEPENDENCIES
   rspec
   rubocop
   rubocop-performance
+  webmock
 
 BUNDLED WITH
    2.3.3

--- a/click_house.gemspec
+++ b/click_house.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-performance'
+  spec.add_development_dependency 'webmock'
 end

--- a/lib/click_house/connection.rb
+++ b/lib/click_house/connection.rb
@@ -63,11 +63,11 @@ module ClickHouse
           end
         end
 
-        conn.response Middleware::RaiseError
         conn.response Middleware::Logging, logger: config.logger!
         conn.response Middleware::SummaryMiddleware, options: { config: config } # should be after logger
         conn.response config.json_parser, content_type: %r{application/json}, options: { config: config }
         conn.response Middleware::ParseCsv, content_type: %r{text/csv}, options: { config: config }
+        conn.response Middleware::RaiseError
         conn.adapter config.adapter
       end
     end

--- a/spec/click_house/connection_spec.rb
+++ b/spec/click_house/connection_spec.rb
@@ -8,7 +8,23 @@ RSpec.describe ClickHouse::Connection do
     end
 
     it 'works' do
-      expect {  subject.tables }.to raise_error(ClickHouse::DbException, /Authentication failed/)
+      expect { subject.tables }.to raise_error(ClickHouse::DbException, /Authentication failed/)
+    end
+  end
+
+  context 'when errors in response' do
+    let(:connection) { ClickHouse::Connection.new(config) }
+    let(:config) { ClickHouse.config.clone.assign(url: 'http://stub/') }
+
+    it 'raises a DbException' do
+      stub_request(:get, /stub/)
+        .to_return(
+          body: "Code: 159. DB::Exception: Timeout exceeded: elapsed 1.009405197 seconds, maximum: 1. (TIMEOUT_EXCEEDED) (version 23.5.4.25 (official build))\n",
+          status: 200,
+          headers: { 'X-ClickHouse-Exception-Code' => '159', 'Content-Type' => 'application/json; charset=UTF-8' }
+        )
+
+      expect { connection.get(body: 'SELECT 1') }.to raise_error(ClickHouse::DbException, /Timeout exceeded/)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ $ROOT_PATH = File.expand_path('../../', __FILE__).freeze
 require 'bundler/setup'
 require 'click_house'
 require 'pry'
+require 'webmock/rspec'
 
 Dir[File.join($ROOT_PATH, 'spec', 'support', '*.rb')].each { |f| require f }
 
@@ -13,6 +14,8 @@ ClickHouse.config do |config|
   config.database = 'click_house_rspec'
   config.url = 'http://localhost:8123?allow_suspicious_low_cardinality_types=1&output_format_arrow_low_cardinality_as_dictionary=1'
 end
+
+WebMock.disable_net_connect!(allow_localhost: true)
 
 RSpec.configure do |config|
   config.example_status_persistence_file_path = '.rspec_status'


### PR DESCRIPTION
Faraday middlewares are being called in [reverse order](https://lostisland.github.io/faraday/#/middleware/index?id=how-it-works).

With the current ordering, you might get a successful (200) response from Clickhouse with an expected content type (application/json), but the response body might contain an error message. This will cause ClickHouse to raise a `JSON::ParserError` or `Oj::ParserError` instead of a `DbException`.

We need to reverse the middleware order to check the response status first and only then attempt to parse the body. 