### PR TITLE
Add read time and support adaptor options (timeout fix with httpx)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ ClickHouse.config do |config|
   config.url = 'http://localhost:8123'
   config.timeout = 60
   config.open_timeout = 3
+  config.read_timeout = 50
   config.ssl_verify = false
   # set to true to symbolize keys for SELECT and INSERT statements (type casting)
   config.symbolize_keys = false
@@ -414,6 +415,7 @@ default: &default
   url: http://localhost:8123
   timeout: 60
   open_timeout: 3
+  read_timeout: 50
 
 development:
   database: ecliptic_development

--- a/lib/click_house/config.rb
+++ b/lib/click_house/config.rb
@@ -14,6 +14,7 @@ module ClickHouse
       password: nil,
       timeout: nil,
       open_timeout: nil,
+      read_timeout: nil,
       ssl_verify: false,
       headers: {},
       global_params: {},
@@ -46,6 +47,7 @@ module ClickHouse
     attr_accessor :password
     attr_accessor :timeout
     attr_accessor :open_timeout
+    attr_accessor :read_timeout
     attr_accessor :ssl_verify
     attr_accessor :headers
     attr_accessor :global_params

--- a/lib/click_house/config.rb
+++ b/lib/click_house/config.rb
@@ -4,6 +4,7 @@ module ClickHouse
   class Config
     DEFAULTS = {
       adapter: Faraday.default_adapter,
+      adapter_options: [],
       url: nil,
       scheme: 'http',
       host: 'localhost',
@@ -37,6 +38,7 @@ module ClickHouse
     }.freeze
 
     attr_accessor :adapter
+    attr_accessor :adapter_options
     attr_accessor :logger
     attr_accessor :scheme
     attr_accessor :host

--- a/lib/click_house/connection.rb
+++ b/lib/click_house/connection.rb
@@ -52,6 +52,7 @@ module ClickHouse
       @transport ||= Faraday.new(config.url!) do |conn|
         conn.options.timeout = config.timeout
         conn.options.open_timeout = config.open_timeout
+        conn.options.read_timeout = config.read_timeout
         conn.headers = config.headers
         conn.ssl.verify = config.ssl_verify
 

--- a/lib/click_house/connection.rb
+++ b/lib/click_house/connection.rb
@@ -69,7 +69,7 @@ module ClickHouse
         conn.response Middleware::SummaryMiddleware, options: { config: config } # should be after logger
         conn.response config.json_parser, content_type: %r{application/json}, options: { config: config }
         conn.response Middleware::ParseCsv, content_type: %r{text/csv}, options: { config: config }
-        conn.adapter config.adapter
+        conn.adapter config.adapter, *config.adapter_options
       end
     end
     # rubocop:enable Metrics/AbcSize


### PR DESCRIPTION
Hello @shlima,

Your work is a piece of art.

I have faced an issue where timeout doesn't work if the request is opened successfully, it just freezes indefinitely, you can reproduce it using this query (Clickhouse doesn't support sleep longer than three seconds):
```sql
-- sleep/process for a long time
SELECT sum(pow(number, 0.5)) FROM numbers(1000000000000)
```

I was able to fix using @HoneyryderChuck's httpx, and based on this article https://honeyryderchuck.gitlab.io/2023/10/15/state-of-ruby-http-clients-use-httpx.html it seems httpx the best option, I think we should move click_house to use it.

When I used it the timeout worked but I needed to add support for adaptor option to pass things like retires and `persistent: false`

I also added read timeout support.