### PR TITLE
Fix bug with global params in get queries

### DIFF
--- a/lib/click_house/extend/connection_selective.rb
+++ b/lib/click_house/extend/connection_selective.rb
@@ -5,12 +5,12 @@ module ClickHouse
     module ConnectionSelective
       # @return [ResultSet]
       def select_all(sql)
-        response = get(body: sql, query: { default_format: 'JSON' })
+        response = get(body: sql, query: query_defaults)
         Response::Factory.response(response, config)
       end
 
       def select_value(sql)
-        response = get(body: sql, query: { default_format: 'JSON' })
+        response = get(body: sql, query: query_defaults)
         got = Response::Factory.response(response, config).first
 
         case got
@@ -24,8 +24,12 @@ module ClickHouse
       end
 
       def select_one(sql)
-        response = get(body: sql, query: { default_format: 'JSON' })
+        response = get(body: sql, query: query_defaults)
         Response::Factory.response(response, config).first
+      end
+
+      def query_defaults
+        config.global_params.merge({default_format: 'JSON'})
       end
     end
   end


### PR DESCRIPTION
## Solution

This PR fixes a bug with applying global params in GET queries

## Problem

When you use `global_params` in config and expect them to be applied for all queries, it fails in `select_all`, `select_one` and `select_value` queries.