### PR TITLE
fix: Pass the correct extensions

### DIFF
--- a/lib/click_house/definition/column_set.rb
+++ b/lib/click_house/definition/column_set.rb
@@ -22,10 +22,10 @@ module ClickHouse
         class_eval <<-METHODS, __FILE__, __LINE__ + 1
           def #{method_name}(*definition)
             name = definition[0]
-            extentions = []
+            extensions = []
             options = {}
-            extensions = Array(definition[1..-1]).each do |el|
-              el.is_a?(Hash) ? options.merge!(el) : extentions.push(el)
+            Array(definition[1..-1]).each do |el|
+              el.is_a?(Hash) ? options.merge!(el) : extensions.push(el)
             end
 
             columns << Column.new(type: "#{type}", name: name, extensions: extensions, **options)


### PR DESCRIPTION
It looks like `extensions` was created with the intention to pass the extensions to the Column constructor. However, a second variable `extentions` was also created to store the extensions identified in the definition args. Unfortunately this second variable was not used, despite containing the desired extensions, and the original variable, which contained the unfiltered definition, was passed to the constructor.

Instead, the variable containing the unfiltered args has been removed, and the typo in the variable containing the filtered list has been corrected. This results in the correct extensions being passed to the Column constructor.