### PR TITLE
fix: Make BooleanType handle 0 correctly

### DIFF
--- a/lib/click_house/type/boolean_type.rb
+++ b/lib/click_house/type/boolean_type.rb
@@ -5,18 +5,14 @@ module ClickHouse
     class BooleanType < BaseType
       TRUE_VALUE = 1
       FALSE_VALUE = 0
+      TRUE_VALUES = Set[1, '1', true].freeze
 
       def cast(value)
-        case value
-        when TrueClass, FalseClass
-          value
-        else
-          value.to_i == TRUE_VALUE
-        end
+        TRUE_VALUES.include?(value)
       end
 
       def serialize(value)
-        value ? TRUE_VALUE : FALSE_VALUE
+        TRUE_VALUES.include?(value) ? TRUE_VALUE : FALSE_VALUE
       end
     end
   end

--- a/spec/click_house/integration/boolean_type_spec.rb
+++ b/spec/click_house/integration/boolean_type_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ClickHouse::Type::BooleanType do
       expect(got.fetch('a')).to be_a(TrueClass)
       expect(got.fetch('b')).to be_a(FalseClass)
       expect(got.fetch('c')).to be_a(TrueClass)
-      expect(got.fetch('b')).to be_a(FalseClass)
+      expect(got.fetch('d')).to be_a(FalseClass)
       expect(got.fetch('e')).to be_a(NilClass)
     end
   end
@@ -58,7 +58,7 @@ RSpec.describe ClickHouse::Type::BooleanType do
       expect(got.fetch('a')).to be_a(TrueClass)
       expect(got.fetch('b')).to be_a(FalseClass)
       expect(got.fetch('c')).to be_a(TrueClass)
-      expect(got.fetch('b')).to be_a(FalseClass)
+      expect(got.fetch('d')).to be_a(FalseClass)
       expect(got.fetch('e')).to be_a(NilClass)
     end
   end


### PR DESCRIPTION
The tests BooleanType had a typo causing them to skip testing serialization of and casting of 0. This meant that even though it treated 0 as a truthy value, it was not caught by the tests.

Instead, BooleanType now uses a list of truthy values for serialization, which now includes 0. This fixes the handling, and the tests have been updated to enforce this behaviour.